### PR TITLE
Fix memory corruption issue

### DIFF
--- a/postgis/build/postgis-3.3.2/libpgcommon/shared_gserialized.c
+++ b/postgis/build/postgis-3.3.2/libpgcommon/shared_gserialized.c
@@ -47,7 +47,17 @@ shared_gserialized_new_cached(FunctionCallInfo fcinfo, Datum d)
 SHARED_GSERIALIZED *
 shared_gserialized_ref(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *ref)
 {
-	if (MemoryContextContains(PostgisCacheContext(fcinfo), ref))
+	/*
+	 * In CBDB, pointer is not guaranteed to always be palloc aligned. Due to
+	 * our use of MemTuples, the pointer may instead point into the palloc'd
+	 * region to an attr offset. Therefore we cannot assume the MemoryContext
+	 * from which the pointer was palloc'd exists in the bytes immediately in
+	 * front of the pointer.
+	 *
+	 * Instead use MemoryContextContainsGenericAllocation() which correctly
+	 * handles the above scenario.
+	 */
+	if (MemoryContextContainsGenericAllocation(PostgisCacheContext(fcinfo), ref))
 	{
 		ref->count++;
 		return ref;
@@ -65,7 +75,17 @@ shared_gserialized_ref(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *ref)
 void
 shared_gserialized_unref(FunctionCallInfo fcinfo, SHARED_GSERIALIZED *ref)
 {
-	if (MemoryContextContains(PostgisCacheContext(fcinfo), ref))
+	/*
+	 * In CBDB, pointer is not guaranteed to always be palloc aligned. Due to
+	 * our use of MemTuples, the pointer may instead point into the palloc'd
+	 * region to an attr offset. Therefore we cannot assume the MemoryContext
+	 * from which the pointer was palloc'd exists in the bytes immediately in
+	 * front of the pointer.
+	 *
+	 * Instead use MemoryContextContainsGenericAllocation() which correctly
+	 * handles the above scenario.
+	 */
+	if (MemoryContextContainsGenericAllocation(PostgisCacheContext(fcinfo), ref))
 	{
 		ref->count--;
 		if (!ref->count)


### PR DESCRIPTION
Fix issue: https://github.com/apache/cloudberry/issues/1395

### **Cause Analysis**
In CBDB, pointer is not guaranteed to always be palloc aligned. Due to our use of MemTuples, the pointer may instead point into the palloc'd region to an attr offset. Therefore we cannot assume the MemoryContext from which the pointer was palloc'd exists in the bytes immediately in front of the pointer.

Instead use MemoryContextContainsGenericAllocation() which correctly handles the above scenario.

### **Test**
#### Basic Validation Test
File: postgis-basic-validation-test.sql
Purpose: Validates basic PostGIS operations work correctly
Result: ✅ All tests pass - NO CRASHES

#### Intensive Stress Test
File: postgis-intensive-raster-test.sql
Purpose: 85+ sequential raster operations to test state accumulation
Result: ✅ All tests pass - NO CRASHES (no distributed operations)

#### Distributed Crash Test (ONLY FILE THAT CRASHES)
File: postgis-distributed-crash-test.sql
Purpose: Reproduces memory corruption in distributed queries
Result: ✅ All tests pass - NO CRASHES

### **Conclusion**
| Operation | Single-Segment | Cross-Segment (Current) | Cross-Segment (Before) | Notes |
|------------|----------------|--------------------------|-------------------------|-------|
| ST_Contains | ✅ Works | ✅ Works | ❌ CRASHES | Prepared geometry cache |
| ST_Intersection | ✅ Works | ✅ Works | ❌ CRASHES | TOAST + motion nodes |
| ST_Intersects | ✅ Works | ✅ Works | ❌ CRASHES | Used in WHERE clauses |
| ST_Within | ✅ Works | ✅ Works | ❌ CRASHES | Prepared predicates |
| ST_DWithin | ✅ Works | ✅ Works | ❌ CRASHES | Distance predicates |
| ST_Buffer | ✅ Works | ✅ Works | ✅ Works | No cache involved |
| ST_AsText | ✅ Works | ✅ Works | ✅ Works | Simple conversion |
| ST_Area | ✅ Works | ✅ Works | ✅ Works | Measurement function |
| ST_Union (agg) | ✅ Works | ✅ Works | ⚠️ May crash | If crosses segments |




<!--Thank you for contributing! -->
<!--In case of an existing issue or discussions, please reference it-->
fix #ISSUE_Number
<!--Remove this section if no corresponding issue.-->

---

## Change logs

> Describe your change clearly, including what problem is being solved or what document is being added or updated.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/apache/cloudberry/blob/main/.gitmessage) as a reference.
* Sign the Contributor License Agreement as prompted for your first-time contribution (*One-time setup*).
* Feel free to ask for the PostGIS for Cloudberry team to help review and approve.
